### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "cpp"
+run = "cmake CMakeLists.txt; make; ./hello"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Hello World
 
+[![Run on Repl.it](https://repl.it/badge/github/pisan343/hello)](https://repl.it/github/pisan343/hello)
+
 A "simple" project to setup the development pipeline check to make sure we get
 
 - compiler warnings


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@pisanuw/hello-2).