### PR TITLE
Added valgrind no-leak-message for Travis CI

### DIFF
--- a/simplecompile.sh
+++ b/simplecompile.sh
@@ -114,6 +114,10 @@ if hash valgrind 2>/dev/null; then
       # "Using Mac Laptop, Darwin Kernel Version 16.7.0"
       NOLEAKMSG="definitely lost: 0 bytes in 0 blocks"
     fi
+    if [ "valgrind-3.11.0" == `valgrind --version 2> /dev/null` ]; then
+      # "Using Travis CI, Xenial Distro Kernel Version 4.15.0-1028-gcp"
+      NOLEAKMSG="definitely lost: 0 bytes in 0 blocks"
+    fi
     grep "$NOLEAKMSG" myprogram-valgrind-output.txt
     # exit status of grep is 0 is no match found, 1 if match found
     LAST_COMMAND_RESULT=$?


### PR DESCRIPTION
My Travis CI build was failing even though there were no memory leaks because simplecomplile.sh was looking for a specific no-leak-message. The message that Valgrind on Travis CI shows was different, so I added an option in simplecompile.sh for it.